### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "koa-send": "^3.2.0",
     "koa-static": "1.5.2",
     "pem": "1.8.1",
-    "request": "2.67.0",
+    "request": "2.74.0",
     "thunkify": "2.1.2",
     "validator": "^5.2.0"
   }


### PR DESCRIPTION
applicationize currently has a 6 vulnerable dependency paths, introducing 4 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
- [ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency.
- [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/eladnava/applicationize) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade others dependency as well.

Stay Secure,
The Snyk Team
